### PR TITLE
Logger fix

### DIFF
--- a/core/logger/src/helper.rs
+++ b/core/logger/src/helper.rs
@@ -33,7 +33,7 @@ pub fn log_to_console(log_level: &String) {
                 "{} [{}] - [{}] {}",
                 Local::now().format("%Y-%m-%dT%H:%M:%S"), // Reformat to human-readable timestamp
                 record.level(),
-                record.module_path_static().unwrap(),
+                record.module_path().unwrap(),
                 record.args(),
             )
         })


### PR DESCRIPTION
Remove usage of module_path_static because when we run with debug, it won't have file path for these components